### PR TITLE
fix: fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
       - name: Checkout Code
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
       - name: Detect unused secrets
         uses: nearform/github-action-detect-unused-secrets@v1
         with:


### PR DESCRIPTION
There example yaml file contains an extra (and problematic) dash.

Fixes #33 